### PR TITLE
typo fix

### DIFF
--- a/leaf_indexes_calculation/leaf_indexes_calculation_tutorial.ipynb
+++ b/leaf_indexes_calculation/leaf_indexes_calculation_tutorial.ipynb
@@ -29,6 +29,7 @@
    "source": [
     "from __future__ import print_function\n",
     "\n",
+    "\n",
     "import numpy  as np\n",
     "from scipy.stats import ttest_rel\n",
     "\n",
@@ -39,6 +40,9 @@
     "from sklearn.metrics import mean_squared_error\n",
     "\n",
     "from catboost import CatBoostRegressor\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", category=ConvergenceWarning)\n",
     "\n",
     "seed = 42"
    ]
@@ -2084,12 +2088,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "97d5fcc4c2f94bdca55c64cf4bf86be5",
+       "model_id": "32fcc6bdcba642b988bd0403786ee525",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "MetricVisualizer(layout=Layout(align_self=u'stretch', height=u'500px'))"
+       "MetricVisualizer(layout=Layout(align_self='stretch', height='500px'))"
       ]
      },
      "metadata": {},
@@ -2116,7 +2120,7 @@
     "cb_regressor = CatBoostRegressor(**catboost_params)\n",
     "cb_regressor.fit(X_train, y_train, eval_set=(X_validate, y_validate), plot=True)\n",
     "print(\"tree count: {}\".format(cb_regressor.tree_count_))\n",
-    "print(\"best rmse: {:.5}\".format(cb_regressor.best_score_['validation_0'][\"RMSE\"]))"
+    "print(\"best rmse: {:.5}\".format(cb_regressor.best_score_['validation'][\"RMSE\"]))"
    ]
   },
   {
@@ -2167,7 +2171,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\strashila\\AppData\\Local\\Continuum\\anaconda2\\lib\\site-packages\\sklearn\\linear_model\\coordinate_descent.py:492: ConvergenceWarning: Objective did not converge. You might want to increase the number of iterations. Fitting data with very small alpha may cause precision problems.\n",
+      "/Users/vadimborisov/anaconda3/lib/python3.7/site-packages/sklearn/linear_model/coordinate_descent.py:492: ConvergenceWarning: Objective did not converge. You might want to increase the number of iterations. Fitting data with very small alpha may cause precision problems.\n",
       "  ConvergenceWarning)\n"
      ]
     },
@@ -2176,7 +2180,7 @@
      "output_type": "stream",
      "text": [
       "best alpha: 0.00316\n",
-      "best rmse:  0.591689214194\n"
+      "best rmse:  0.5916892141942673\n"
      ]
     }
    ],
@@ -2269,21 +2273,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.15"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
`cb_regressor.best_score_['validation_0']` does not work anymore, we have to access the 'validation' item. 