### PR TITLE
model2.predict(X_test), get IndexError by use custom_loss!

### DIFF
--- a/custom_loss/custom_loss_and_metric_tutorial.ipynb
+++ b/custom_loss/custom_loss_and_metric_tutorial.ipynb
@@ -280,6 +280,7 @@
     "                            learning_rate=0.03, bootstrap_type='Bayesian', boost_from_average=False,\n",
     "                            leaf_estimation_iterations=1, leaf_estimation_method='Gradient')\n",
     "model1.fit(X_train, y_train, eval_set=(X_test, y_test))"
+    "model1.predict(X_test)"
    ]
   },
   {
@@ -323,6 +324,7 @@
     "                            learning_rate=0.03, bootstrap_type='Bayesian', boost_from_average=False,\n",
     "                            leaf_estimation_iterations=1, leaf_estimation_method='Gradient')\n",
     "model2.fit(X_train, y_train, eval_set=(X_test, y_test))"
+    "model2.predict(X_test)"
    ]
   },
   {
@@ -455,6 +457,7 @@
     "                           learning_rate=0.03, bootstrap_type='Bayesian', boost_from_average=False,\n",
     "                           leaf_estimation_iterations=1, leaf_estimation_method='Gradient')\n",
     "model1.fit(X_train, y_train, eval_set=(X_test, y_test))"
+    "model1.predict(X_test)"
    ]
   },
   {
@@ -498,6 +501,7 @@
     "                           learning_rate=0.03, bootstrap_type='Bayesian', boost_from_average=False,\n",
     "                           leaf_estimation_iterations=1, leaf_estimation_method='Gradient')\n",
     "model2.fit(X_train, y_train, eval_set=(X_test, y_test))"
+    "model2.predict(X_test)"
    ]
   },
   {
@@ -652,6 +656,7 @@
     "                           learning_rate=0.03, bootstrap_type='Bayesian', boost_from_average=False,\n",
     "                           leaf_estimation_iterations=1, leaf_estimation_method='Newton', classes_count=5)\n",
     "model1.fit(X_train, y_train, eval_set=(X_test, y_test))"
+    "model1.predict(X_test)"
    ]
   },
   {
@@ -695,6 +700,7 @@
     "                           learning_rate=0.03, bootstrap_type='Bayesian', boost_from_average=False,\n",
     "                           leaf_estimation_iterations=1, leaf_estimation_method='Newton', classes_count=5)\n",
     "model2.fit(X_train, y_train, eval_set=(X_test, y_test))"
+    "model2.predict(X_test)"
    ]
   }
  ],


### PR DESCRIPTION
model2.predict(X_test)

get IndexError on Python 3.8.8 64-bit, and Python 3.9.7, like this:

Traceback (most recent call last):

  File "E:\py\catboost\tutorials\custom_loss\custom_loss_and_metric_tutorial.py", line 187, in <module>
    model2.predict(X_test,thread_count=1,prediction_type='Class')

  File "C:\ProgramData\Anaconda3\lib\site-packages\catboost\core.py", line 4772, in predict
    return self._predict(data, prediction_type, ntree_start, ntree_end, thread_count, verbose, 'predict', task_type)

  File "C:\ProgramData\Anaconda3\lib\site-packages\catboost\core.py", line 2220, in _predict
    predictions = self._base_predict(data, prediction_type, ntree_start, ntree_end, thread_count, verbose, task_type)

  File "C:\ProgramData\Anaconda3\lib\site-packages\catboost\core.py", line 1516, in _base_predict
    return self._object._base_predict(pool, prediction_type, ntree_start, ntree_end, thread_count, verbose, task_type)

  File "_catboost.pyx", line 4529, in _catboost._CatBoost._base_predict

  File "_catboost.pyx", line 4546, in _catboost._CatBoost._base_predict

  File "_catboost.pyx", line 1609, in _catboost.transform_predictions

  File "_catboost.pyx", line 5350, in _catboost._convert_to_visible_labels

IndexError: index 0 is out of bounds for axis 0 with size 0
